### PR TITLE
Remove unused imports

### DIFF
--- a/src/llm/deepseek_llm.py
+++ b/src/llm/deepseek_llm.py
@@ -3,7 +3,6 @@ DeepSeek LLM实现
 """
 
 import requests
-import json
 from typing import Dict, Any, Optional, List
 from .base_llm import BaseLLM
 

--- a/src/rerankers/cross_encoder_reranker.py
+++ b/src/rerankers/cross_encoder_reranker.py
@@ -1,8 +1,7 @@
 """Cross-Encoder重排器实现"""
 
 import logging
-from typing import List, Dict, Any, Tuple
-import numpy as np
+from typing import List, Dict, Any
 from .base_reranker import BaseReranker
 
 try:


### PR DESCRIPTION
## Summary
- remove unused numpy and Tuple imports from `CrossEncoderReranker`
- drop unused json import from `DeepSeekLLM`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68bfca9ec74c8320a4d4ca9f476de28b