### PR TITLE
chore: package project and clean base command imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "categoryrag"
+version = "0.1.0"
+description = "CategoryRAG system"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+authors = [{name = "CategoryRAG Team"}]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/cli/commands/base_command.py
+++ b/src/cli/commands/base_command.py
@@ -22,15 +22,9 @@ License: MIT
 
 import logging
 from abc import ABC, abstractmethod
-from pathlib import Path
 import sys
 
-# 添加项目根目录到Python路径
-project_root = Path(__file__).parent.parent.parent.parent
-sys.path.insert(0, str(project_root))
-sys.path.insert(0, str(project_root / 'src'))
-
-from src.config.enhanced_config_manager import EnhancedConfigManager
+from ...config.enhanced_config_manager import EnhancedConfigManager
 
 class BaseCommand(ABC):
     """基础命令类"""


### PR DESCRIPTION
## Summary
- add pyproject.toml to package CategoryRAG and allow module imports
- simplify BaseCommand to rely on package-relative imports

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*
- `pip install -e .` *(fails: Could not find a version that satisfies setuptools>=61.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcaa2dcd88320951c6d93f23811fa