### PR TITLE
chore: remove unused Path import

### DIFF
--- a/tests/multi_collection_test.py
+++ b/tests/multi_collection_test.py
@@ -6,7 +6,6 @@
 import os
 import sys
 import logging
-from pathlib import Path
 
 # 添加src目录到Python路径
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))


### PR DESCRIPTION
## Summary
- remove unused `Path` import from tests

## Testing
- `python tests/multi_collection_test.py` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68bfcaa3f4a48320920caff222dd28d6